### PR TITLE
opti categories和tag汇总页面,显示原始的名字!

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
 </header>
 <div class="post-archive">
     {{ range .Data.Terms.ByCount }}
-    <h2><a href="{{ path.Join $.Data.Plural .Term | urlize | absLangURL }}">{{ .Term }}</a> ({{ .Count }})</h2>
+    <h2><a href="{{ path.Join $.Data.Plural .Term | urlize | absLangURL }}">{{ .Page.Title }}</a> ({{ .Count }})</h2>
     <ul class="listing">
         {{ range .Pages }}
         <li>


### PR DESCRIPTION
categories 和 tag 在汇总展示页面，使用原始的名字！使用{{ .Term }} 会转成小写!