### PR TITLE
opti: 去除代码区域添加的边框!

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -104,7 +104,6 @@ pre, code {
 }
 pre {
     overflow:auto;
-    border: 1px solid #ddd;
     display: block;
 }
 code {
@@ -373,7 +372,7 @@ textarea {
     overflow: hidden;
 }
 .post-content pre{
-    padding: 1em;
+    padding: 1em 0 1em 1em;
 }
 .post-content code{
     display:inline;


### PR DESCRIPTION
您好，我使用的是hugo v0.62默认的高亮主题`highlight.style = "monokai" `, 行号和代码中间会有一条白竖线，为了使代码和行号看起来使一个整体。

您看下这样是否合理？
修改前的效果：
![image](https://user-images.githubusercontent.com/5516080/71710702-8ef9c000-2e38-11ea-9eca-5146ad60980c.png)
修改后的效果：
![image](https://user-images.githubusercontent.com/5516080/71710771-d2ecc500-2e38-11ea-9bb5-6f5d2feffcd4.png)
