### PR TITLE
fix:调整目录显示，解决目录内容显示异常问题

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,7 +12,10 @@
                     {{ block "content" . }}{{ end }}
                 </div>
 
-                {{ partial "sidebar" . }}
+                {{ if hasPrefix .RelPermalink "/post/" }}
+                {{ else }}
+                    {{ partial "sidebar" . }}
+                {{ end }}
             </div>
         </div>
     </div>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -2,8 +2,12 @@
 <style type="text/css">
     .post-toc {
         position: fixed;
-        width: 200px;
-        margin-left: -210px;
+        width:fit-content;
+        width:-webkit-fit-content;
+        width:-moz-fit-content;
+        max-width: 300px;
+        min-width: 100px;
+        right: 10%;
         padding: 5px 10px;
         font-family: Athelas, STHeiti, Microsoft Yahei, serif;
         font-size: 12px;
@@ -70,11 +74,6 @@
     $(document).ready(function () {
         var postToc = $(".post-toc");
         if (postToc.length) {
-            var leftPos = $("#main").offset().left;
-            if(leftPos<220){
-                postToc.css({"width":leftPos-10,"margin-left":(0-leftPos)})
-            }
-
             var t = postToc.offset().top - 20,
                 a = {
                     start: {


### PR DESCRIPTION
1.文章内容页不显示 slidebar，其他页面正常显示 slidebar;
2.将目录显示到左边，并自适应宽度（限制最大、最小长度）；