### PR TITLE
增加分类和标签的聚合页链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Maupassant theme, ported to Hugo.
 21. 文章自定义摘要
 22. 自定义广告支持
 23. 自定义备案信息
+24. 自定义图片CDN
+25. 图片点击放大
 
 ## 下载安装
 
@@ -213,6 +215,27 @@ type: archives
 ```
 
 以上配置中的备案信息要换成自己的
+
+#### 图片点击放大
+
+将会引入jquery.js 和 fancybox 的css和js
+
+```toml
+[params]
+  fancybox = true
+```
+
+#### 图片CDN
+
+将会在mark中引入的图片src前面加上设置的host, 有http前缀的路径不会在前面加入host
+注意: 路径后面不要带/ 
+> 可直接使用jsdelivr加速 后面跟上github仓库即可 
+
+```toml
+[params.image_cdn]
+    enable = true
+    Host = "https://cdn.jsdelivr.net/gh/user/user.github.io"
+```
 
 #### Disqus
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,29 @@
+{{- $img_destination := .Destination -}}
+{{- if (or .Page.Site.Params.image_cdn.enable (not .Page.Site.IsServer)) -}}
+    {{if hasPrefix .Destination "/" }}
+    {{ $img_destination = (print .Page.Site.Params.image_cdn.HOST .Destination) }}
+    {{ else if not (hasPrefix .Destination "http") }}
+    {{ $img_destination = (print .Page.Site.Params.image_cdn.HOST (path.Join .Page.RelPermalink .Destination)) }}
+    {{ end }}
+{{- end -}}
+
+{{- if .Title -}}
+<figure class="max-w-2xl mx-auto overflow-hidden">
+    {{if .Page.Site.Params.fancybox }}
+    <a data-fancybox="gallery" href="{{ $img_destination | safeURL }}">
+        <img alt="{{ $.Text }}" src="{{ $img_destination | safeURL }}" />
+    </a>
+    {{ else }}
+        <img alt="{{ $.Text }}" src="{{ $img_destination | safeURL }}" />
+    {{ end }}
+    <figcaption class="p-2 text-center">{{ with $.Title | safeHTML }}{{ . }}{{ end }}</figcaption>
+</figure>
+{{- else -}}
+    {{if .Page.Site.Params.fancybox }}
+        <a data-fancybox="gallery" href="{{ $img_destination | safeURL }}">
+            <img class="mx-auto" alt="{{ $.Text }}" src="{{ $img_destination | safeURL }}" />
+        </a>
+    {{ else }}
+        <img class="mx-auto" alt="{{ $.Text }}" src="{{ $img_destination | safeURL }}" />   
+    {{ end }}
+{{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -121,6 +121,11 @@
             };
     </script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
+    
+    {{- if .Site.Params.fancybox -}}
+        <script src="https://cdn.bootcdn.net/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+        <script src="https://cdn.bootcdn.net/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js"></script>
+    {{- end -}}
 {{ end }}
 
 <a id="rocket" href="#top"></a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,6 +42,10 @@
     <script data-ad-client="{{ .Site.Params.googleAd }}" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     {{ end }}
     
+    {{if .Site.Params.fancybox }}
+        <link href="https://cdn.bootcdn.net/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.css" rel="stylesheet">
+    {{ end }}
+    
     <!-- custom css -->
     {{ range .Site.Params.customCSS }}
         <link rel="stylesheet" href='{{ "/css/" | relURL }}{{ . }}'>


### PR DESCRIPTION
我看hogo都生成了,干脆加上吧.否则这个html岂不是浪费了

点击右侧 `分类` 或者 `标签`  即可跳转到对应聚合页