### PR TITLE
fix favicon may not load in published site

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
         {{- end }}
     {{- end }}
     <meta property="og:url" content="{{ .Permalink }}">
-    <link rel="shortcut icon" href='{{ "favicon.ico/" | relURL }}'  type="image/x-icon">
+    <link rel="shortcut icon" href='{{ "favicon.ico" | relURL }}'  type="image/x-icon">
 
     <link rel="stylesheet" href='{{ "css/normalize.css" | relURL}}'>
     <link rel="stylesheet" href='{{ "css/style.css" | relURL }}'>


### PR DESCRIPTION
老哥上一次的提交好像给head.html的favicon多加了一个"/"，`<link rel="shortcut icon" href='{{ "favicon.ico/" | relURL }}'  type="image/x-icon">`
这会导致hugo生成静态文件时，favicon会变成这种链接，`<link rel="shortcut icon" href=/favicon.ico/ type=image/x-icon>`，导致无法识别favicon
Hugo本地实时预览的话，没有这个问题。我是用GitHub Action生成的静态文件，会对静态文件进行压缩。尝试去掉这个"/"后，一切正常