### PR TITLE
fix busuanzi counting error above Chrome 85

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ if .Site.Params.busuanzi }}
+    <meta name="referrer" content="no-referrer-when-downgrade">
+    {{ end }}
 
     {{ if .IsHome -}}
     <title>{{ .Site.Title }} | {{ .Site.Params.subtitle}}</title>


### PR DESCRIPTION
老哥，那个busuanzi计数在Chrome85以上的版本里，计数有问题，会变得很大
因为Chome新版本改了默认的Referrer Policy，从原来的`no-referrer-when-downgrade`改成了`strict-origin-when-cross-origin`
可以参考[A new default Referrer-Policy for Chrome: strict-origin-when-cross-origin](https://developers.google.com/web/updates/2020/07/referrer-policy-new-chrome-default#summary)
官方也说了可以手动修改Referrer Policy，我就加了一下