### PR TITLE
feat: 自动隐藏文章目录/站点副标题为空时隐藏竖线

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,8 +8,13 @@
     {{ end }}
 
     {{ if .IsHome -}}
+    {{ if .Site.Params.subtitle -}}
     <title>{{ .Site.Title }} | {{ .Site.Params.subtitle}}</title>
     <meta property="og:title" content="{{ .Site.Title }} | {{ .Site.Params.subtitle}}">
+    {{ else -}}
+    <title>{{ .Site.Title }}</title>
+    <meta property="og:title" content="{{ .Site.Title }}">
+    {{ end -}}
     <meta property="og:type" content="website">
     <meta name="Keywords" content="{{.Site.Params.keywords}}">
     <meta name="description" content="{{ .Site.Params.description }}">

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -71,8 +71,8 @@
         var postToc = $(".post-toc");
         if (postToc.length) {
             var leftPos = $("#main").offset().left;
-            if(leftPos<220){
-                postToc.css({"width":leftPos-10,"margin-left":(0-leftPos)})
+            if (leftPos < 220) {
+                postToc.css({ "width": leftPos - 10, "margin-left": (0 - leftPos) })
             }
 
             var t = postToc.offset().top - 20,
@@ -90,6 +90,10 @@
                 var e = $(window).scrollTop();
                 e < t ? postToc.css(a.start) : postToc.css(a.process)
             })
+        }
+
+        if ($("#TableOfContents").children().length < 1) {
+            $(".post-toc").remove();
         }
     })
 </script>


### PR DESCRIPTION
- 文章目录为空的时候自动隐藏文章页面左侧的“文章目录”（因为对 Hugo 的模板不太熟悉，所以用 jQuery 实现了）
- 网站副标题为空时去掉网站标题后面的竖线（` | `）