### PR TITLE
创建了index.xml，修改了rss功能。

### DIFF
--- a/layouts/index.xml
+++ b/layouts/index.xml
@@ -1,0 +1,39 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" -}}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range first 10 $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Content | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
创建了index.xml文件。现在rss订阅是输出最近10篇文章的全文内容。

使用自建的miniflux订阅你博客rss的时候会提示时间错误

<img width="817" alt="image" src="https://user-images.githubusercontent.com/15084031/177944436-e1a1267a-0602-48e6-a59f-e6ea5da4be02.png">

是生成的rss文件中时区有错误。

<img width="729" alt="image" src="https://user-images.githubusercontent.com/15084031/177944542-29e8d907-21a3-4460-8431-e75fdc06e23d.png">

我用新版的`hugo v0.101.0+extended darwin/arm64 BuildDate=unknown`新建一个站点，生成的时区是正常的：

<img width="897" alt="image" src="https://user-images.githubusercontent.com/15084031/177944722-41ad2208-4509-4361-aeea-b98457e42b2f.png">

不清楚是不是你的hugo版本的问题。

我没有找到主题中关于rss的xml文件，为了解决这个潜在的bug，我创建了`layouts/index.xml`的文件，并修改成了输出最近10片文章的全文内容。

非常喜欢你的博客，希望能解决这个订阅的bug。
