### PR TITLE
新的国际化支持 | New Internationalization support

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,99 @@
+# Lang: English (generic)
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# BGN: Date and Time Formats
+  [datetimeformat]
+    other = "2006-01-02"
+  [datetimelongtzd]
+    other = "2006-01-02 15:04:05 Z07:00"
+  [datetimelongtzn]
+    other = "2006-01-02 15:04:05 MST"
+  [datetimetzd]
+    other = "2006-01-02 15:04 Z07:00"
+  [datetimetzn]
+    other = "2006-01-02 15:04 MST"
+  [datetimeonly]
+    other = "2006-01-02 15:04"
+  [dateonly]
+    other = "2006-01-02"
+  [timelongtzd]
+    other = "15:04:05 Z07:00"
+  [timelongtzn]
+    other = "15:04:05 MST"
+  [timetzd]
+    other = "15:04 Z07:00"
+  [timetzn]
+    other = "15:04 MST"
+  [timeonly]
+    other = "15:04"
+# END: Date and Time Formats
+
+# BGN: Base
+  [home]
+    other = "Home"
+
+  [categories]
+    one = "Category"
+    other = "Categories"
+  [tags]
+    one = "Tag"
+    other = "Tags"
+
+  [readmore]
+    other = "Read more"
+
+  [next]
+    other = "Next"
+  [previous]
+    other = "Previous"
+
+  [toc]
+    other = "Table of Contents"
+# END: Base
+
+# BGN: Theme
+  [ads]
+    other = "Ads"
+
+  [articles]
+    other = "articles"
+  [articles-latest]
+    other = "Latest articles"
+  [articles-related]
+    other = "See Also"
+
+  [busuanzi]
+    other = "reads"
+
+  [feed-rss]
+    other = "RSS"
+
+  [links]
+    other = "Links"
+
+  [meta]
+    other = "Meta"
+
+  [tagszero]
+    other = "No tags"
+
+  [search]
+    other = "Search: "
+  [search-keyword]
+    other = "Keyword"
+  [search-results]
+    other = "results"
+# END: Theme
+
+# BGN: Copyright
+  [copyright-author]
+    other = "Author: "
+  [copyright-link]
+    other = "Link: "
+  [copyright-license]
+    other = "License: "
+  [copyright-license-01]
+    other = "This work is under a "
+  [copyright-license-02]
+    other = "Kindly fulfill the requirements of the aforementioned License when adapting or creating a derivative of this work."
+# END: Copyright

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,32 +1,10 @@
 # Lang: English (generic)
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
-# BGN: Date and Time Formats
-  [datetimeformat]
+# BGN: Date and Time Format
+  [Datetime_format]
     other = "2006-01-02"
-  [datetimelongtzd]
-    other = "2006-01-02 15:04:05 Z07:00"
-  [datetimelongtzn]
-    other = "2006-01-02 15:04:05 MST"
-  [datetimetzd]
-    other = "2006-01-02 15:04 Z07:00"
-  [datetimetzn]
-    other = "2006-01-02 15:04 MST"
-  [datetimeonly]
-    other = "2006-01-02 15:04"
-  [dateonly]
-    other = "2006-01-02"
-  [timelongtzd]
-    other = "15:04:05 Z07:00"
-  [timelongtzn]
-    other = "15:04:05 MST"
-  [timetzd]
-    other = "15:04 Z07:00"
-  [timetzn]
-    other = "15:04 MST"
-  [timeonly]
-    other = "15:04"
-# END: Date and Time Formats
+# END: Date and Time Format
 
 # BGN: Base
   [home]
@@ -39,8 +17,8 @@
     one = "Tag"
     other = "Tags"
 
-  [readmore]
-    other = "Read more"
+  [continueReading]
+    other = "Continue reading"
 
   [next]
     other = "Next"
@@ -55,17 +33,17 @@
   [ads]
     other = "Ads"
 
-  [articles]
+  [Articles]
     other = "articles"
-  [articles-latest]
+  [Articles_latest]
     other = "Latest articles"
-  [articles-related]
+  [Articles_related]
     other = "See Also"
 
   [busuanzi]
     other = "reads"
 
-  [feed-rss]
+  [Feed_rss]
     other = "RSS"
 
   [links]
@@ -74,26 +52,26 @@
   [meta]
     other = "Meta"
 
-  [tagszero]
+  [tagsNone]
     other = "No tags"
 
-  [search]
+  [Search]
     other = "Search: "
-  [search-keyword]
+  [Search_keyword]
     other = "Keyword"
-  [search-results]
+  [Search_results]
     other = "results"
 # END: Theme
 
 # BGN: Copyright
-  [copyright-author]
+  [Copyright_author]
     other = "Author: "
-  [copyright-link]
+  [Copyright_link]
     other = "Link: "
-  [copyright-license]
+  [Copyright_license]
     other = "License: "
-  [copyright-license-01]
+  [Copyright_license_workUnder]
     other = "This work is under a "
-  [copyright-license-02]
+  [Copyright_license_note]
     other = "Kindly fulfill the requirements of the aforementioned License when adapting or creating a derivative of this work."
 # END: Copyright

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,0 +1,99 @@
+# Lang: Japanese
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# BGN: Date and Time Formats
+  [datetimeformat]
+    other = "2006年1月2日"
+  [datetimelongtzd]
+    other = "2006年1月2日 15:04:05 Z07:00"
+  [datetimelongtzn]
+    other = "2006年1月2日 15:04:05 MST"
+  [datetimetzd]
+    other = "2006年1月2日 15:04 Z07:00"
+  [datetimetzn]
+    other = "2006年1月2日 15:04 MST"
+  [datetimeonly]
+    other = "2006年1月2日 15:04"
+  [dateonly]
+    other = "2006年1月2日"
+  [timelongtzd]
+    other = " 15:04:05 Z07:00"
+  [timelongtzn]
+    other = " 15:04:05 MST"
+  [timetzd]
+    other = " 15:04 Z07:00"
+  [timetzn]
+    other = " 15:04 MST"
+  [timeonly]
+    other = " 15:04"
+# END: Date and Time Formats
+
+# BGN: Base
+  [home]
+    other = "自宅"
+
+  [categories]
+    one = "カテゴリ"
+    other = "カテゴリ"
+  [tags]
+    one = "タグ"
+    other = "タグ"
+
+  [readmore]
+    other = "詳細はこちら"
+
+  [next]
+    other = "次へ"
+  [previous]
+    other = "前の"
+
+  [toc]
+    other = "目次"
+# END: Base
+
+# BGN: Theme
+  [ads]
+    other = "広告です"
+
+  [articles]
+    other = "記事です"
+  [articles-latest]
+    other = "最新の記事です"
+  [articles-related]
+    other = "関連記事です"
+
+  [busuanzi]
+    other = "読みます。"
+
+  [feed-rss]
+    other = "RSSフィード"
+
+  [links]
+    other = "リンク"
+
+  [meta]
+    other = "メタ"
+
+  [tagszero]
+    other = "タグなし"
+
+  [search]
+    other = "検索"
+  [search-keyword]
+    other = "キーワード"
+  [search-results]
+    other = "検索結果"
+# END: Theme
+
+# BGN: Copyright
+  [copyright-author]
+    other = "作成者:"
+  [copyright-link]
+    other = "リンク:"
+  [copyright-license]
+    other = "ライセンス:"
+  [copyright-license-01]
+    other = "この作業は、次の条件の下にあります。"
+  [copyright-license-02]
+    other = "本作業のデリバティブを適用または作成する場合は、上記のライセンスの要件を満たしてください。"
+# END: Copyright

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,32 +1,10 @@
 # Lang: Japanese
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
-# BGN: Date and Time Formats
-  [datetimeformat]
+# BGN: Date and Time Format
+  [Datetime_format]
     other = "2006年1月2日"
-  [datetimelongtzd]
-    other = "2006年1月2日 15:04:05 Z07:00"
-  [datetimelongtzn]
-    other = "2006年1月2日 15:04:05 MST"
-  [datetimetzd]
-    other = "2006年1月2日 15:04 Z07:00"
-  [datetimetzn]
-    other = "2006年1月2日 15:04 MST"
-  [datetimeonly]
-    other = "2006年1月2日 15:04"
-  [dateonly]
-    other = "2006年1月2日"
-  [timelongtzd]
-    other = " 15:04:05 Z07:00"
-  [timelongtzn]
-    other = " 15:04:05 MST"
-  [timetzd]
-    other = " 15:04 Z07:00"
-  [timetzn]
-    other = " 15:04 MST"
-  [timeonly]
-    other = " 15:04"
-# END: Date and Time Formats
+# END: Date and Time Format
 
 # BGN: Base
   [home]
@@ -39,7 +17,7 @@
     one = "タグ"
     other = "タグ"
 
-  [readmore]
+  [continueReading]
     other = "詳細はこちら"
 
   [next]
@@ -55,17 +33,17 @@
   [ads]
     other = "広告です"
 
-  [articles]
+  [Articles]
     other = "記事です"
-  [articles-latest]
+  [Articles_latest]
     other = "最新の記事です"
-  [articles-related]
+  [Articles_related]
     other = "関連記事です"
 
   [busuanzi]
     other = "読みます。"
 
-  [feed-rss]
+  [Feed_rss]
     other = "RSSフィード"
 
   [links]
@@ -74,26 +52,26 @@
   [meta]
     other = "メタ"
 
-  [tagszero]
+  [tagsNone]
     other = "タグなし"
 
-  [search]
+  [Search]
     other = "検索"
-  [search-keyword]
+  [Search_keyword]
     other = "キーワード"
-  [search-results]
+  [Search_results]
     other = "検索結果"
 # END: Theme
 
 # BGN: Copyright
-  [copyright-author]
+  [Copyright_author]
     other = "作成者:"
-  [copyright-link]
+  [Copyright_link]
     other = "リンク:"
-  [copyright-license]
+  [Copyright_license]
     other = "ライセンス:"
-  [copyright-license-01]
+  [Copyright_license_workUnder]
     other = "この作業は、次の条件の下にあります。"
-  [copyright-license-02]
+  [Copyright_license_note]
     other = "本作業のデリバティブを適用または作成する場合は、上記のライセンスの要件を満たしてください。"
 # END: Copyright

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,32 +1,10 @@
 # Lang: Korean (South)
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
-# BGN: Date and Time Formats
-  [datetimeformat]
+# BGN: Date and Time Format
+  [Datetime_format]
     other = "2006년 01월 02일"
-  [datetimelongtzd]
-    other = "2006년 01월 02일 15:04:05 Z07:00"
-  [datetimelongtzn]
-    other = "2006년 01월 02일 15:04:05 MST"
-  [datetimetzd]
-    other = "2006년 01월 02일 15:04 Z07:00"
-  [datetimetzn]
-    other = "2006년 01월 02일 15:04 MST"
-  [datetimeonly]
-    other = "2006년 01월 02일 15:04"
-  [dateonly]
-    other = "2006년 01월 02일"
-  [timelongtzd]
-    other = "15:04:05 Z07:00"
-  [timelongtzn]
-    other = "15:04:05 MST"
-  [timetzd]
-    other = "15:04 Z07:00"
-  [timetzn]
-    other = "15:04 MST"
-  [timeonly]
-    other = "15:04"
-# END: Date and Time Formats
+# END: Date and Time Format
 
 # BGN: Base
   [home]
@@ -39,7 +17,7 @@
     one = "태그입니다."
     other = "태그입니다."
 
-  [readmore]
+  [continueReading]
     other = "더 읽기"
 
   [next]
@@ -55,17 +33,17 @@
   [ads]
     other = "광고"
 
-  [articles]
+  [Articles]
     other = "기사들"
-  [articles-latest]
+  [Articles_latest]
     other = "최신 기사입니다."
-  [articles-related]
+  [Articles_related]
     other = "관련기사입니다"
 
   [busuanzi]
     other = "읽습니다."
 
-  [feed-rss]
+  [Feed_rss]
     other = "RSS 피드"
 
   [links]
@@ -74,26 +52,26 @@
   [meta]
     other = "메타"
 
-  [tagszero]
+  [tagsNone]
     other = "태그 없음"
 
-  [search]
+  [Search]
     other = "서치"
-  [search-keyword]
+  [Search_keyword]
     other = "핵심어"
-  [search-results]
+  [Search_results]
     other = "결과."
 # END: Theme
 
 # BGN: Copyright
-  [copyright-author]
+  [Copyright_author]
     other = "작가: "
-  [copyright-link]
+  [Copyright_link]
     other = "링크: "
-  [copyright-license]
+  [Copyright_license]
     other = " 허가하다: "
-  [copyright-license-01]
+  [Copyright_license_workUnder]
     other = "이 작업은 아래에 있습니다."
-  [copyright-license-02]
+  [Copyright_license_note]
     other = "이 작업의 파생 모델을 수정하거나 작성할 때 앞서 언급한 라이센스의 요구 사항을 충족하십시오."
 # END: Copyright

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,0 +1,99 @@
+# Lang: Korean (South)
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# BGN: Date and Time Formats
+  [datetimeformat]
+    other = "2006년 01월 02일"
+  [datetimelongtzd]
+    other = "2006년 01월 02일 15:04:05 Z07:00"
+  [datetimelongtzn]
+    other = "2006년 01월 02일 15:04:05 MST"
+  [datetimetzd]
+    other = "2006년 01월 02일 15:04 Z07:00"
+  [datetimetzn]
+    other = "2006년 01월 02일 15:04 MST"
+  [datetimeonly]
+    other = "2006년 01월 02일 15:04"
+  [dateonly]
+    other = "2006년 01월 02일"
+  [timelongtzd]
+    other = "15:04:05 Z07:00"
+  [timelongtzn]
+    other = "15:04:05 MST"
+  [timetzd]
+    other = "15:04 Z07:00"
+  [timetzn]
+    other = "15:04 MST"
+  [timeonly]
+    other = "15:04"
+# END: Date and Time Formats
+
+# BGN: Base
+  [home]
+    other = "집이에요"
+
+  [categories]
+    one = "분류"
+    other = "분류"
+  [tags]
+    one = "태그입니다."
+    other = "태그입니다."
+
+  [readmore]
+    other = "더 읽기"
+
+  [next]
+    other = "다음 분."
+  [previous]
+    other = "이전의"
+
+  [toc]
+    other = "목차."
+# END: Base
+
+# BGN: Theme
+  [ads]
+    other = "광고"
+
+  [articles]
+    other = "기사들"
+  [articles-latest]
+    other = "최신 기사입니다."
+  [articles-related]
+    other = "관련기사입니다"
+
+  [busuanzi]
+    other = "읽습니다."
+
+  [feed-rss]
+    other = "RSS 피드"
+
+  [links]
+    other = "링크입니다."
+
+  [meta]
+    other = "메타"
+
+  [tagszero]
+    other = "태그 없음"
+
+  [search]
+    other = "서치"
+  [search-keyword]
+    other = "핵심어"
+  [search-results]
+    other = "결과."
+# END: Theme
+
+# BGN: Copyright
+  [copyright-author]
+    other = "작가: "
+  [copyright-link]
+    other = "링크: "
+  [copyright-license]
+    other = " 허가하다: "
+  [copyright-license-01]
+    other = "이 작업은 아래에 있습니다."
+  [copyright-license-02]
+    other = "이 작업의 파생 모델을 수정하거나 작성할 때 앞서 언급한 라이센스의 요구 사항을 충족하십시오."
+# END: Copyright

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -1,32 +1,10 @@
 # Lang: Simplified Chinese (China)
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
-# BGN: Date and Time Formats
-  [datetimeformat]
+# BGN: Date and Time Format
+  [Datetime_format]
     other = "2006年1月2日"
-  [datetimelongtzd]
-    other = "2006年1月2日 15:04:05 Z07:00"
-  [datetimelongtzn]
-    other = "2006年1月2日 15:04:05 MST"
-  [datetimetzd]
-    other = "2006年1月2日 15:04 Z07:00"
-  [datetimetzn]
-    other = "2006年1月2日 15:04 MST"
-  [datetimeonly]
-    other = "2006年1月2日 15:04"
-  [dateonly]
-    other = "2006年1月2日"
-  [timelongtzd]
-    other = " 15:04:05 Z07:00"
-  [timelongtzn]
-    other = " 15:04:05 MST"
-  [timetzd]
-    other = " 15:04 Z07:00"
-  [timetzn]
-    other = " 15:04 MST"
-  [timeonly]
-    other = " 15:04"
-# END: Date and Time Formats
+# END: Date and Time Format
 
 # BGN: Base
   [home]
@@ -39,7 +17,7 @@
     one = "标签"
     other = "标签"
 
-  [readmore]
+  [continueReading]
     other = "阅读全文"
 
   [next]
@@ -55,17 +33,17 @@
   [ads]
     other = "福利派送"
 
-  [articles]
+  [Articles]
     other = "中的文章"
-  [articles-latest]
+  [Articles_latest]
     other = "最近文章"
-  [articles-related]
+  [Articles_related]
     other = "相关文章"
 
   [busuanzi]
     other = "阅读"
 
-  [feed-rss]
+  [Feed_rss]
     other = "文章 RSS"
 
   [links]
@@ -74,26 +52,26 @@
   [meta]
     other = "其它"
 
-  [tagszero]
+  [tagsNone]
     other = "没有标签"
 
-  [search]
+  [Search]
     other = "搜索"
-  [search-keyword]
+  [Search_keyword]
     other = "哈哈"
-  [search-results]
+  [Search_results]
     other = "的结果"
 # END: Theme
 
 # BGN: Copyright
-  [copyright-author]
+  [Copyright_author]
     other = "原文作者："
-  [copyright-link]
+  [Copyright_link]
     other = "原文链接："
-  [copyright-license]
+  [Copyright_license]
     other = "版权声明："
-  [copyright-license-01]
+  [Copyright_license_workUnder]
     other = "本作品采用"
-  [copyright-license-02]
+  [Copyright_license_note]
     other = "进行许可，非商业转载请注明出处（作者，原文链接），商业转载请联系作者获得授权。"
 # END: Copyright

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -1,0 +1,99 @@
+# Lang: Simplified Chinese (China)
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# BGN: Date and Time Formats
+  [datetimeformat]
+    other = "2006年1月2日"
+  [datetimelongtzd]
+    other = "2006年1月2日 15:04:05 Z07:00"
+  [datetimelongtzn]
+    other = "2006年1月2日 15:04:05 MST"
+  [datetimetzd]
+    other = "2006年1月2日 15:04 Z07:00"
+  [datetimetzn]
+    other = "2006年1月2日 15:04 MST"
+  [datetimeonly]
+    other = "2006年1月2日 15:04"
+  [dateonly]
+    other = "2006年1月2日"
+  [timelongtzd]
+    other = " 15:04:05 Z07:00"
+  [timelongtzn]
+    other = " 15:04:05 MST"
+  [timetzd]
+    other = " 15:04 Z07:00"
+  [timetzn]
+    other = " 15:04 MST"
+  [timeonly]
+    other = " 15:04"
+# END: Date and Time Formats
+
+# BGN: Base
+  [home]
+    other = "首页"
+
+  [categories]
+    one = "分类"
+    other = "分类"
+  [tags]
+    one = "标签"
+    other = "标签"
+
+  [readmore]
+    other = "阅读全文"
+
+  [next]
+    other = "下一页"
+  [previous]
+    other = "上一页"
+
+  [toc]
+    other = "文章目录"
+# END: Base
+
+# BGN: Theme
+  [ads]
+    other = "福利派送"
+
+  [articles]
+    other = "中的文章"
+  [articles-latest]
+    other = "最近文章"
+  [articles-related]
+    other = "相关文章"
+
+  [busuanzi]
+    other = "阅读"
+
+  [feed-rss]
+    other = "文章 RSS"
+
+  [links]
+    other = "友情链接"
+
+  [meta]
+    other = "其它"
+
+  [tagszero]
+    other = "没有标签"
+
+  [search]
+    other = "搜索"
+  [search-keyword]
+    other = "哈哈"
+  [search-results]
+    other = "的结果"
+# END: Theme
+
+# BGN: Copyright
+  [copyright-author]
+    other = "原文作者："
+  [copyright-link]
+    other = "原文链接："
+  [copyright-license]
+    other = "版权声明："
+  [copyright-license-01]
+    other = "本作品采用"
+  [copyright-license-02]
+    other = "进行许可，非商业转载请注明出处（作者，原文链接），商业转载请联系作者获得授权。"
+# END: Copyright

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -1,32 +1,10 @@
 # Lang: Simplified Chinese (China)
 # https://gohugo.io/content-management/multilingual/#translation-of-strings
 
-# BGN: Date and Time Formats
-  [datetimeformat]
+# BGN: Date and Time Format
+  [Datetime_format]
     other = "2006年1月2日"
-  [datetimelongtzd]
-    other = "2006年1月2日 15:04:05 Z07:00"
-  [datetimelongtzn]
-    other = "2006年1月2日 15:04:05 MST"
-  [datetimetzd]
-    other = "2006年1月2日 15:04 Z07:00"
-  [datetimetzn]
-    other = "2006年1月2日 15:04 MST"
-  [datetimeonly]
-    other = "2006年1月2日 15:04"
-  [dateonly]
-    other = "2006年1月2日"
-  [timelongtzd]
-    other = " 15:04:05 Z07:00"
-  [timelongtzn]
-    other = " 15:04:05 MST"
-  [timetzd]
-    other = " 15:04 Z07:00"
-  [timetzn]
-    other = " 15:04 MST"
-  [timeonly]
-    other = " 15:04"
-# END: Date and Time Formats
+# END: Date and Time Format
 
 # BGN: Base
   [home]
@@ -39,7 +17,7 @@
     one = "標籤"
     other = "標籤"
 
-  [readmore]
+  [continueReading]
     other = "閱讀全文"
 
   [next]
@@ -55,17 +33,17 @@
   [ads]
     other = "福利派送"
 
-  [articles]
+  [Articles]
     other = "中的文章"
-  [articles-latest]
+  [Articles_latest]
     other = "最近文章"
-  [articles-related]
+  [Articles_related]
     other = "相關文章"
 
   [busuanzi]
     other = "閱讀"
 
-  [feed-rss]
+  [Feed_rss]
     other = "文章 RSS"
 
   [links]
@@ -74,26 +52,26 @@
   [meta]
     other = "其它"
 
-  [tagszero]
+  [tagsNone]
     other = "沒有標籤"
 
-  [search]
+  [Search]
     other = "搜索"
-  [search-keyword]
+  [Search_keyword]
     other = "哈哈"
-  [search-results]
+  [Search_results]
     other = "的結果"
 # END: Theme
 
 # BGN: Copyright
-  [copyright-author]
+  [Copyright_author]
     other = "原文作者："
-  [copyright-link]
+  [Copyright_link]
     other = "原文鏈接："
-  [copyright-license]
+  [Copyright_license]
     other = "原文鏈接："
-  [copyright-license-01]
+  [Copyright_license_workUnder]
     other = "本作品採用"
-  [copyright-license-02]
+  [Copyright_license_note]
     other = "進行許可，非商業轉載請註明出處（作者，原文鏈接），商業轉載請聯繫作者獲得授權。"
 # END: Copyright

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -1,0 +1,99 @@
+# Lang: Simplified Chinese (China)
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# BGN: Date and Time Formats
+  [datetimeformat]
+    other = "2006年1月2日"
+  [datetimelongtzd]
+    other = "2006年1月2日 15:04:05 Z07:00"
+  [datetimelongtzn]
+    other = "2006年1月2日 15:04:05 MST"
+  [datetimetzd]
+    other = "2006年1月2日 15:04 Z07:00"
+  [datetimetzn]
+    other = "2006年1月2日 15:04 MST"
+  [datetimeonly]
+    other = "2006年1月2日 15:04"
+  [dateonly]
+    other = "2006年1月2日"
+  [timelongtzd]
+    other = " 15:04:05 Z07:00"
+  [timelongtzn]
+    other = " 15:04:05 MST"
+  [timetzd]
+    other = " 15:04 Z07:00"
+  [timetzn]
+    other = " 15:04 MST"
+  [timeonly]
+    other = " 15:04"
+# END: Date and Time Formats
+
+# BGN: Base
+  [home]
+    other = "首頁"
+
+  [categories]
+    one = "分類"
+    other = "分類"
+  [tags]
+    one = "標籤"
+    other = "標籤"
+
+  [readmore]
+    other = "閱讀全文"
+
+  [next]
+    other = "下一頁"
+  [previous]
+    other = "上一頁"
+
+  [toc]
+    other = "文章目錄"
+# END: Base
+
+# BGN: Theme
+  [ads]
+    other = "福利派送"
+
+  [articles]
+    other = "中的文章"
+  [articles-latest]
+    other = "最近文章"
+  [articles-related]
+    other = "相關文章"
+
+  [busuanzi]
+    other = "閱讀"
+
+  [feed-rss]
+    other = "文章 RSS"
+
+  [links]
+    other = "友情鏈接"
+
+  [meta]
+    other = "其它"
+
+  [tagszero]
+    other = "沒有標籤"
+
+  [search]
+    other = "搜索"
+  [search-keyword]
+    other = "哈哈"
+  [search-results]
+    other = "的結果"
+# END: Theme
+
+# BGN: Copyright
+  [copyright-author]
+    other = "原文作者："
+  [copyright-link]
+    other = "原文鏈接："
+  [copyright-license]
+    other = "原文鏈接："
+  [copyright-license-01]
+    other = "本作品採用"
+  [copyright-license-02]
+    other = "進行許可，非商業轉載請註明出處（作者，原文鏈接），商業轉載請聯繫作者獲得授權。"
+# END: Copyright

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -13,7 +13,7 @@
         <div class="post-content">
             {{ .Summary }}……
         </div>
-        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "readmore" }}</a></p>
+        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "continueReading" }}</a></p>
     </article>
     {{ end }}
     {{ end }}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -9,23 +9,11 @@
                 <a href="{{ .Permalink }}" title="{{ .Title }}" target="_blank">{{ .Title }}</a>
             </h1>
         </header>
-        <date class="post-meta meta-date">
-            {{ .Date.Year }}年{{ printf "%d" .Date.Month }}月{{ .Date.Day }}日
-        </date>
-        {{ with .Params.Categories }}
-        <div class="post-meta">
-            <span>|</span>
-            {{ range . }}
-            <span class="meta-category">
-                <a href='{{ "categories/" | relURL }}{{ . | urlize }}' target="_blank">{{ . }}</a>
-            </span>
-            {{ end }}
-        </div>
-        {{ end }}
+        {{ partial "post-meta.html" . }}
         <div class="post-content">
             {{ .Summary }}……
         </div>
-        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">阅读全文</a></p>
+        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "readmore" }}</a></p>
     </article>
     {{ end }}
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,7 +36,7 @@
                 {{ end }}
             </ul>
             {{ else }}
-            {{ i18n "tagszero" }}
+            {{ i18n "tagsNone" }}
             {{ end }}
         </div>
     </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,29 +5,18 @@
         <header>
             <h1 class="post-title">{{ .Title }}</h1>
         </header>
-        <date class="post-meta meta-date">
-            {{ .Date.Year }}年{{ printf "%d" .Date.Month }}月{{ .Date.Day }}日
-        </date>
-        {{ with .Params.Categories }}
-        <div class="post-meta">
-            <span>|</span>
-            {{ range . }}
-            <span class="meta-category">
-                <a href='{{ "categories/" | relURL }}{{ . | urlize }}' target="_blank">{{ . }}</a>
-            </span>
-            {{ end }}
-        </div>
-        {{ end }}
+        {{ partial "post-meta.html" . }}
         {{ if .Site.Params.busuanzi }}
         <div class="post-meta">
-            <span id="busuanzi_container_page_pv">|<span id="busuanzi_value_page_pv"></span><span>
-                    阅读</span></span>
+            <span id="busuanzi_container_page_pv">&nbsp;|
+                <span id="busuanzi_value_page_pv"></span> <span>{{ i18n "busuanzi" }}</span>
+            </span>
         </div>
         {{ end }}
         {{ if .Params.toc }}
         <div class="clear" style="display: none">
             <div class="toc-article">
-                <div class="toc-title">文章目录</div>
+                <div class="toc-title">{{ i18n "toc" }}</div>
             </div>
         </div>
         {{ end }}
@@ -47,7 +36,7 @@
                 {{ end }}
             </ul>
             {{ else }}
-            没有标签
+            {{ i18n "tagszero" }}
             {{ end }}
         </div>
     </article>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,15 +2,19 @@
 <div class="res-cons">
     {{ if eq .Data.Singular "category" }}
     <h3 class="archive-title">
-        分类
+        {{ range .Site.Taxonomies.categories.ByCount }}
+            <span>{{ .Count }}</span>
+        {{ end }}
         <span class="keyword">{{ .Data.Term }}</span>
-        中的文章
+        {{ i18n "articles" }}
     </h3>
     {{ else if eq .Data.Singular "tag" }}
     <h3 class="archive-title">
-        包含标签
+        {{ range .Site.Taxonomies.tags.ByCount }}
+        <span>{{ .Count }}</span>
+        {{ end }}
         <span class="keyword">{{ .Data.Term }}</span>
-        的文章
+        {{ i18n "articles" }}
     </h3>
     {{ end }}
 
@@ -21,20 +25,10 @@
                 <a href="{{ .Permalink }}" target="_blank">{{ .Title }}</a>
             </h1>
         </header>
-        <date class="post-meta meta-date">
-            {{ .Date.Year }}年{{ printf "%d" .Date.Month }}月{{ .Date.Day }}日
-        </date>
-        {{ with .Params.Categories }}
-        <div class="post-meta meta-category">
-            |
-            {{ range . }}
-            <a href='{{ "categories/" | relURL }}{{ . | urlize }}' target="_blank">{{ . }}</a>
-            {{ end }}
-        </div>
-        {{ end }}
+        {{ partial "post-meta.html" . }}
         <div class="post-content">
             {{ .Summary }}……
-            <p class="readmore"><a href="{{ .Permalink }}" target="_blank">阅读全文</a></p>
+            <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "readmore" }}</a></p>
         </div>
     </article>
     {{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -6,7 +6,7 @@
             <span>{{ .Count }}</span>
         {{ end }}
         <span class="keyword">{{ .Data.Term }}</span>
-        {{ i18n "articles" }}
+        {{ i18n "Articles" }}
     </h3>
     {{ else if eq .Data.Singular "tag" }}
     <h3 class="archive-title">
@@ -14,7 +14,7 @@
         <span>{{ .Count }}</span>
         {{ end }}
         <span class="keyword">{{ .Data.Term }}</span>
-        {{ i18n "articles" }}
+        {{ i18n "Articles" }}
     </h3>
     {{ end }}
 
@@ -28,7 +28,7 @@
         {{ partial "post-meta.html" . }}
         <div class="post-content">
             {{ .Summary }}……
-            <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "readmore" }}</a></p>
+            <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "continueReading" }}</a></p>
         </div>
     </article>
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
         <div class="post-content">
             {{ .Summary }}……
         </div>
-        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "readmore" }}</a></p>
+        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "continueReading" }}</a></p>
     </article>
     {{ end }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,23 +9,11 @@
                 <a href="{{ .Permalink }}" title="{{ .Title }}" target="_blank">{{ .Title }}</a>
             </h1>
         </header>
-        <date class="post-meta meta-date">
-            {{ .Date.Year }}年{{ printf "%d" .Date.Month }}月{{ .Date.Day }}日
-        </date>
-        {{ with .Params.Categories }}
-        <div class="post-meta">
-            <span>|</span>
-            {{ range . }}
-            <span class="meta-category">
-                <a href='{{ "categories/" | relURL }}{{ . | urlize }}' target="_blank">{{ . }}</a>
-            </span>
-            {{ end }}
-        </div>
-        {{ end }}
+        {{ partial "post-meta.html" . }}
         <div class="post-content">
             {{ .Summary }}……
         </div>
-        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">阅读全文</a></p>
+        <p class="readmore"><a href="{{ .Permalink }}" target="_blank">{{ i18n "readmore" }}</a></p>
     </article>
     {{ end }}
     {{ end }}

--- a/layouts/partials/ads.html
+++ b/layouts/partials/ads.html
@@ -1,6 +1,6 @@
 {{ with .Site.Params.ads }}
 <section class="widget">
-    <h3 class="widget-title" style="color:red">福利派送</h3>
+    <h3 class="widget-title" style="color:red">{{ i18n "ads" }}</h3>
     <ul class="widget-list">
         {{ range . }}
         <li>

--- a/layouts/partials/categories.html
+++ b/layouts/partials/categories.html
@@ -1,4 +1,4 @@
-<h3 class="widget-title"><a href='{{ "categories/" | relURL }}'>分类</a></h3>
+<h3 class="widget-title"><a href='{{ "categories/" | relURL }}'>{{ i18n "categories" }}</a></h3>
 <ul class="widget-list">
     {{ range .Site.Taxonomies.categories }}
     <li><a href="{{ .Page.Permalink }}">{{ .Page.Title }} ({{ .Count }})</a></li>

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,9 +1,9 @@
 {{ if and (isset .Site.Params "cc")  (in (slice "post" "posts") .Type) }}
 <div class="post-archive">
     <ul class="post-copyright">
-        <li><strong>原文作者：</strong><a rel="author" href="{{ .Site.BaseURL}}">{{ if isset .Site.Author "name" }}{{.Site.Author.name}}{{ else }}{{.Site.Title}}{{ end }}</a></li>
-        <li style="word-break:break-all"><strong>原文链接：</strong><a href="{{ .Permalink}}">{{ .Permalink}}</a></li>
-        <li><strong>版权声明：</strong>本作品采用<a rel="license" href="{{.Site.Params.cc.link}}">{{.Site.Params.cc.name}}</a>进行许可，非商业转载请注明出处（作者，原文链接），商业转载请联系作者获得授权。</li>
+        <li><strong>{{ i18n "copyright-author" }}</strong><a rel="author" href="{{ .Site.BaseURL}}">{{ if isset .Site.Author "name" }}{{.Site.Author.name}}{{ else }}{{.Site.Title}}{{ end }}</a></li>
+        <li style="word-break:break-all"><strong>{{ i18n "copyright-link" }}</strong><a href="{{ .Permalink}}">{{ .Permalink}}</a></li>
+        <li><strong>{{ i18n "copyright-license" }}</strong>{{ i18n "copyright-license-01" }}<a rel="license" href="{{.Site.Params.cc.link}}">{{.Site.Params.cc.name}}</a>. {{ i18n "copyright-license-02" }}</li>
     </ul>
 </div>
 <br/>

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,9 +1,9 @@
 {{ if and (isset .Site.Params "cc")  (in (slice "post" "posts") .Type) }}
 <div class="post-archive">
     <ul class="post-copyright">
-        <li><strong>{{ i18n "copyright-author" }}</strong><a rel="author" href="{{ .Site.BaseURL}}">{{ if isset .Site.Author "name" }}{{.Site.Author.name}}{{ else }}{{.Site.Title}}{{ end }}</a></li>
-        <li style="word-break:break-all"><strong>{{ i18n "copyright-link" }}</strong><a href="{{ .Permalink}}">{{ .Permalink}}</a></li>
-        <li><strong>{{ i18n "copyright-license" }}</strong>{{ i18n "copyright-license-01" }}<a rel="license" href="{{.Site.Params.cc.link}}">{{.Site.Params.cc.name}}</a>. {{ i18n "copyright-license-02" }}</li>
+        <li><strong>{{ i18n "Copyright_author" }}</strong><a rel="author" href="{{ .Site.BaseURL}}">{{ if isset .Site.Author "name" }}{{.Site.Author.name}}{{ else }}{{.Site.Title}}{{ end }}</a></li>
+        <li style="word-break:break-all"><strong>{{ i18n "Copyright_link" }}</strong><a href="{{ .Permalink}}">{{ .Permalink}}</a></li>
+        <li><strong>{{ i18n "Copyright_license" }}</strong>{{ i18n "Copyright_license_workUnder" }}<a rel="license" href="{{.Site.Params.cc.link}}">{{.Site.Params.cc.name}}</a>. {{ i18n "Copyright_license_note" }}</li>
     </ul>
 </div>
 <br/>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
             </div>
             <div>
                 <nav id="nav-menu" class="clearfix">
-                    <a class="{{ if or (.IsHome) (eq .Type "post") (eq .Type "posts") }}current{{ end }}" href="{{ .Site.BaseURL | absURL }}">首页</a>
+                    <a class="{{ if or (.IsHome) (eq .Type "post") (eq .Type "posts") }}current{{ end }}" href="{{ .Site.BaseURL | absURL }}">{{ i18n "home" }}</a>
                     {{ range .Site.Menus.main }}
                     <a {{ if eq .URL $.RelPermalink }}class="current"{{ end }} href="{{ .URL | absURL }}" title="{{ .Name }}">{{ .Name }}</a>
                     {{ end }}

--- a/layouts/partials/links.html
+++ b/layouts/partials/links.html
@@ -1,6 +1,6 @@
 {{ with .Site.Params.links }}
 <section class="widget">
-    <h3 class="widget-title">友情链接</h3>
+    <h3 class="widget-title">{{ i18n "links" }}</h3>
     <ul class="widget-list">
         {{ range . }}
         <li>

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -5,7 +5,7 @@
 <ol class="page-navigator">
     {{ if .HasPrev }}
     <li class="prev">
-        <a href="{{ .Prev.URL | absLangURL }}">上一页</a>
+        <a href="{{ .Prev.URL | absLangURL }}">{{ i18n "previous" }}</a>
     </li>
     {{ end }}
 
@@ -46,10 +46,10 @@
     {{ end }}
 
     {{ if .HasNext }}
-    
+
 
     <li class="next">
-        <a href="{{ .Next.URL | absLangURL }}">下一页</a>
+        <a href="{{ .Next.URL | absLangURL }}">{{ i18n "next" }}</a>
     </li>
     {{ end }}
 </ol>
@@ -58,7 +58,7 @@
 <ol class="page-navigator">
     {{ if .HasPrev }}
     <li class="prev">
-        <a href="{{ .Prev.URL | absLangURL }}">上一页</a>
+        <a href="{{ .Prev.URL | absLangURL }}">{{ i18n "previous" }}</a>
     </li>
     {{ end }}
 
@@ -70,7 +70,7 @@
 
     {{ if .HasNext }}
     <li class="next">
-        <a href="{{ .Next.URL | absLangURL }}">下一页</a>
+        <a href="{{ .Next.URL | absLangURL }}">{{ i18n "next" }}</a>
     </li>
     {{ end }}
 </ol>

--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,0 +1,14 @@
+{{- $datetimeformat := i18n "datetimeformat" -}}
+{{ if not .PublishDate.IsZero }}
+  <time datetime="{{ .PublishDate.UTC.Format "2006-01-02T15:04:05Z07:00" }}" class="post-meta meta-date dt-published">
+    {{ time.Format $datetimeformat .PublishDate }}
+  </time>
+{{ end }}
+{{ with .Params.Categories }}
+<div class="post-meta meta-category">
+  <span>&nbsp;|</span>
+  {{ range . }}
+    <a href='{{ "categories/" | relURL }}{{ . | urlize }}' target="_blank">{{ . }}</a>
+  {{ end }}
+</div>
+{{ end }}

--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -1,7 +1,7 @@
-{{- $datetimeformat := i18n "datetimeformat" -}}
+{{- $datetime_format := i18n "Datetime_format" -}}
 {{ if not .PublishDate.IsZero }}
   <time datetime="{{ .PublishDate.UTC.Format "2006-01-02T15:04:05Z07:00" }}" class="post-meta meta-date dt-published">
-    {{ time.Format $datetimeformat .PublishDate }}
+    {{ time.Format $datetime_format .PublishDate }}
   </time>
 {{ end }}
 {{ with .Params.Categories }}

--- a/layouts/partials/recent_post.html
+++ b/layouts/partials/recent_post.html
@@ -1,4 +1,4 @@
-<h3 class="widget-title">{{ i18n "articles-latest" }}</h3>
+<h3 class="widget-title">{{ i18n "Articles_latest" }}</h3>
 <ul class="widget-list">
     {{ range first 10 (where (where .Site.Pages "Type" "in" (slice "post" "posts")) "Kind" "page") }}
     <li>

--- a/layouts/partials/recent_post.html
+++ b/layouts/partials/recent_post.html
@@ -1,4 +1,4 @@
-<h3 class="widget-title">最近文章</h3>
+<h3 class="widget-title">{{ i18n "articles-latest" }}</h3>
 <ul class="widget-list">
     {{ range first 10 (where (where .Site.Pages "Type" "in" (slice "post" "posts")) "Kind" "page") }}
     <li>

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,7 +1,7 @@
 {{ $related := .Site.RegularPages.Related . | first 5 }}
 {{ with $related }}
 <div class="post-archive">
-    <h2>{{ i18n "articles-related" }}</h2>
+    <h2>{{ i18n "Articles_related" }}</h2>
     <ul class="listing">
         {{ range . }}
         <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,7 +1,7 @@
 {{ $related := .Site.RegularPages.Related . | first 5 }}
 {{ with $related }}
 <div class="post-archive">
-    <h2>See Also</h2>
+    <h2>{{ i18n "articles-related" }}</h2>
     <ul class="listing">
         {{ range . }}
         <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -22,7 +22,7 @@
     <section class="widget">
         <h3 class="widget-title">{{ i18n "meta" }}</h3>
         <ul class="widget-list">
-            <li><a href="{{ "index.xml" | absURL }}">{{ i18n "feed-rss" }}</a></li>
+            <li><a href="{{ "index.xml" | absURL }}">{{ i18n "Feed_rss" }}</a></li>
         </ul>
     </section>
 </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
     <section class="widget">
         {{ partial "search_form" . }}
     </section>
-    
+
     <section class="widget">
         {{ partial "recent_post" . }}
     </section>
@@ -20,9 +20,9 @@
     {{ partial "links" . }}
 
     <section class="widget">
-        <h3 class="widget-title">其它</h3>
+        <h3 class="widget-title">{{ i18n "meta" }}</h3>
         <ul class="widget-list">
-            <li><a href="{{ "index.xml" | absURL }}">文章 RSS</a></li>
+            <li><a href="{{ "index.xml" | absURL }}">{{ i18n "feed-rss" }}</a></li>
         </ul>
     </section>
 </div>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,4 +1,4 @@
-<h3 class="widget-title"><a href='{{ "tags/" | relURL }}'>标签</a></h3>
+<h3 class="widget-title"><a href='{{ "tags/" | relURL }}'>{{ i18n "tags" }}</a></h3>
 <div class="tagcloud">
     {{ range .Site.Taxonomies.tags }}
     <a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -61,7 +61,7 @@
     }
 </style>
 <div class="post-toc" style="position: absolute; top: 188px;">
-    <h2 class="post-toc-title">文章目录</h2>
+    <h2 class="post-toc-title">{{ i18n "toc" }}</h2>
     <div class="post-toc-content">
         {{.TableOfContents}}
     </div>

--- a/layouts/search/single.html
+++ b/layouts/search/single.html
@@ -1,10 +1,10 @@
 {{ define "content"}}
-{{- $datetimeformat := i18n "datetimeformat" -}}
+{{- $datetime_format := i18n "Datetime_format" -}}
 <div class="res-cons">
     <h3 class="archive-title">
-        {{ i18n "search" }}
-        <span class="keyword">{{ i18n "search-keyword" }}</span>
-        {{ i18n "search-results" }}
+        {{ i18n "Search" }}
+        <span class="keyword">{{ i18n "Search_keyword" }}</span>
+        {{ i18n "Search_results" }}
     </h3>
 
     <article class="post">
@@ -13,10 +13,10 @@
                 <a href="链接" target="_blank">标题</a>
             </h1>
         </header>
-        {{ if not .PublishDate.IsZero }}<time datetime="{{ .PublishDate.UTC.Format "2006-01-02T15:04:05Z07:00" }}" class="post-meta meta-date dt-published">{{ time.Format $datetimeformat .PublishDate }}</time>{{ end }}
+        {{ if not .PublishDate.IsZero }}<time datetime="{{ .PublishDate.UTC.Format "2006-01-02T15:04:05Z07:00" }}" class="post-meta meta-date dt-published">{{ time.Format $datetime_format .PublishDate }}</time>{{ end }}
         <div class="post-content">
             概要……
-            <p class="readmore"><a href="链接" target="_blank">{{ i18n "readmore" }}</a></p>
+            <p class="readmore"><a href="链接" target="_blank">{{ i18n "continueReading" }}</a></p>
         </div>
     </article>
 
@@ -55,7 +55,7 @@
                         var searchItem = `<article class="post"><header><h1 class="post-title"><a href="` + url + `" target="_blank">` + title + `</a></h1></header>`;
                         var pubDate = new Date(item.find("pubDate").text())
                         searchItem += `<time class="post-meta meta-date">` + pubDate.getFullYear() + `-` + (pubDate.getMonth() + 1) + `-` + pubDate.getDate() + `</time>`;
-                        searchItem += `<div class="post-content">` + item.find("description").text() + `……<p class="readmore"><a href="` + url + `" target="_blank">{{ i18n "readmore" }}</a></p></div></article>`;
+                        searchItem += `<div class="post-content">` + item.find("description").text() + `……<p class="readmore"><a href="` + url + `" target="_blank">{{ i18n "continueReading" }}</a></p></div></article>`;
 
                         $("div.res-cons").append(searchItem);
                     }

--- a/layouts/search/single.html
+++ b/layouts/search/single.html
@@ -1,9 +1,10 @@
 {{ define "content"}}
+{{- $datetimeformat := i18n "datetimeformat" -}}
 <div class="res-cons">
     <h3 class="archive-title">
-        搜索
-        <span class="keyword">哈哈</span>
-        的结果
+        {{ i18n "search" }}
+        <span class="keyword">{{ i18n "search-keyword" }}</span>
+        {{ i18n "search-results" }}
     </h3>
 
     <article class="post">
@@ -12,12 +13,10 @@
                 <a href="链接" target="_blank">标题</a>
             </h1>
         </header>
-        <date class="post-meta meta-date">
-            2019年12月01日
-        </date>
+        {{ if not .PublishDate.IsZero }}<time datetime="{{ .PublishDate.UTC.Format "2006-01-02T15:04:05Z07:00" }}" class="post-meta meta-date dt-published">{{ time.Format $datetimeformat .PublishDate }}</time>{{ end }}
         <div class="post-content">
             概要……
-            <p class="readmore"><a href="链接" target="_blank">阅读全文</a></p>
+            <p class="readmore"><a href="链接" target="_blank">{{ i18n "readmore" }}</a></p>
         </div>
     </article>
 
@@ -55,8 +54,8 @@
                         var url = item.find("link").text();
                         var searchItem = `<article class="post"><header><h1 class="post-title"><a href="` + url + `" target="_blank">` + title + `</a></h1></header>`;
                         var pubDate = new Date(item.find("pubDate").text())
-                        searchItem += `<date class="post-meta meta-date">` + pubDate.getFullYear() + `年` + (pubDate.getMonth() + 1) + `月` + pubDate.getDate() + `日</date>`;
-                        searchItem += `<div class="post-content">` + item.find("description").text() + `……<p class="readmore"><a href="` + url + `" target="_blank">阅读全文</a></p></div></article>`;
+                        searchItem += `<time class="post-meta meta-date">` + pubDate.getFullYear() + `-` + (pubDate.getMonth() + 1) + `-` + pubDate.getDate() + `</time>`;
+                        searchItem += `<div class="post-content">` + item.find("description").text() + `……<p class="readmore"><a href="` + url + `" target="_blank">{{ i18n "readmore" }}</a></p></div></article>`;
 
                         $("div.res-cons").append(searchItem);
                     }


### PR DESCRIPTION
Added i18n support.

## Changelog
- ref: moved hardcoded text to `i18n/zh-hans.toml`
- new: languages / translations
  - `i18n/en.toml`
  - `i18n/zh-hant.toml` (Papago translation)
  - `i18n/ko.toml` (Papago translation)
  - `i18n/ja.toml` (Papago translation)
- fix: `<date>` elements to `<time>`

## Example usage
In `config.toml`
```
defaultContentLanguage = "zh-hans"
defaultContentLanguageInSubdir = false
hasCJKLanguage = true
languageCode = "zh-Hans"
```

In `[languages]` or `languages.toml`
```
[zh-hans]
  languageName = "中文（简体）"
  languageCode = "zh-Hans"
  timeZone = "Asia/Shanghai"
  weight = 131
  [[zh-hans.menu.main]]
    identifier = "about"
    name = "关于"
    url = "/about/"
    weight = 2
  [[zh-hans.menu.main]]
    identifier = "archives"
    name = "归档"
    url = "/archives/"
    weight = 3
```

## References
- [Hugo: Translation of Strings](https://gohugo.io/content-management/multilingual/#translation-of-strings)
- [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
- [Language tags in HTML and XML](https://www.w3.org/International/articles/language-tags/)

---

增加了i18n支持。

## Changelog
- ref:将硬编码文本移动到 `i18n/process-hans.toml`
- new:语言/翻译
  - 托尔
  - `i18n/zh-hant.toml` (帕帕戈翻译)
  - `i18n/ko.toml` (帕帕戈翻译)
  - `i18n/ja.toml` (帕帕戈翻译)
- fix: `<date>` 元素到 `<time>`

## 示例用法
在`config.toml`
```
defaultContentLanguage = "zh-hans"
defaultContentLanguageInSubdir = false
hasCJKLanguage = true
languageCode = "zh-Hans"
```

`[languages]`个或`languages.toml`个
```
[zh-hans]
  languageName = "中文（简体）"
  languageCode = "zh-Hans"
  timeZone = "Asia/Shanghai"
  weight = 131
  [[zh-hans.menu.main]]
    identifier = "about"
    name = "关于"
    url = "/about/"
    weight = 2
  [[zh-hans.menu.main]]
    identifier = "archives"
    name = "归档"
    url = "/archives/"
    weight = 3
```

## 参考资料
- [Hugo: Translation of Strings](https://gohugo.io/content-management/multilingual/#translation-of-strings)
- [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
- [Language tags in HTML and XML](https://www.w3.org/International/articles/language-tags/)

