### PR TITLE
feat: 修复2个问题

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,17 +2,13 @@
 <div class="res-cons">
     {{ if eq .Data.Singular "category" }}
     <h3 class="archive-title">
-        {{ range .Site.Taxonomies.categories.ByCount }}
-            <span>{{ .Count }}</span>
-        {{ end }}
+        分类
         <span class="keyword">{{ .Data.Term }}</span>
         {{ i18n "Articles" }}
     </h3>
     {{ else if eq .Data.Singular "tag" }}
     <h3 class="archive-title">
-        {{ range .Site.Taxonomies.tags.ByCount }}
-        <span>{{ .Count }}</span>
-        {{ end }}
+        包含标签
         <span class="keyword">{{ .Data.Term }}</span>
         {{ i18n "Articles" }}
     </h3>

--- a/layouts/search/single.html
+++ b/layouts/search/single.html
@@ -55,7 +55,7 @@
                         var searchItem = `<article class="post"><header><h1 class="post-title"><a href="` + url + `" target="_blank">` + title + `</a></h1></header>`;
                         var pubDate = new Date(item.find("pubDate").text())
                         searchItem += `<time class="post-meta meta-date">` + pubDate.getFullYear() + `-` + (pubDate.getMonth() + 1) + `-` + pubDate.getDate() + `</time>`;
-                        searchItem += `<div class="post-content">` + item.find("description").text() + `……<p class="readmore"><a href="` + url + `" target="_blank">{{ i18n "continueReading" }}</a></p></div></article>`;
+                        searchItem += `<div class="post-content">` + item.find("description").text() + `……<p class="readmore"><a href="` + url + `" target="_blank">` + {{ i18n "continueReading" }} + `</a></p></div></article>`;
 
                         $("div.res-cons").append(searchItem);
                     }


### PR DESCRIPTION
修复2个问题：
1 hugo v0.115.3 编译问题，详见 #167 
2  点击分类（或标签）显示一长串数字，恢复为之前的逻辑：
![image](https://github.com/flysnow-org/maupassant-hugo/assets/5516080/8a2de0b3-da87-4b56-853e-cd31e4234e80)
