### PR TITLE
修复新版 Hugo 代码块行号问题

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -107,9 +107,6 @@ pre {
 code {
     display: inline-block;
 }
-pre code {
-    text-wrap: wrap;
-}
 blockquote {
     display: block;
     margin-block-start: 1em;


### PR DESCRIPTION
Hugo 很早就给代码块增加了底部滚动条，这个样式与行号默认样式冲突，如果要保留，还需要写一个行号的样式覆盖默认样式。最好的方法是直接删除该样式。